### PR TITLE
Break apart BuiltInFunctions mega class

### DIFF
--- a/Donatello.Services/BuiltIns/Def.cs
+++ b/Donatello.Services/BuiltIns/Def.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Donatello.Services.BuiltIns
+{
+    class Def : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            // (def a:int 5)
+            var name = children[1].GetText();
+            var type = visitor.Visit(children[2]) as TypeSyntax;
+            var value = visitor.Visit(children[3]) as ExpressionSyntax;
+            return FieldDeclaration(
+                VariableDeclaration(type, SingletonSeparatedList(
+                    VariableDeclarator(name).WithInitializer(EqualsValueClause(value)))));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/DefMacro.cs
+++ b/Donatello.Services/BuiltIns/DefMacro.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.BuiltIns;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class DefMacro : IBuiltIn
+    {
+        private static Defn Defn = new Defn();
+
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var result = Defn.Invoke(visitor, children) as MethodDeclarationSyntax;
+            Macros.AddMacro(result, visitor.NamespaceName, visitor.ClassName);
+            return result; // return the macro as a function so other programs can reference it.
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Defn.cs
+++ b/Donatello.Services/BuiltIns/Defn.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Donatello.Services.Antlr.Generated.DonatelloParser;
+using Donatello.Services.Util;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    class Defn : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var methodName = children[1].GetText();
+            var parameters = children[2].GetChild(0);
+
+            var parameterList = parameters.As<VectorContext>().form().InPairs((name, type) =>
+            {
+                return Parameter(Identifier(name.GetText()))
+                    .WithType(visitor.Visit(type) as TypeSyntax);
+            });
+
+            var returnType = visitor.Visit(children[3]) as TypeSyntax;
+            var statements = children.Skip(4).Select(statement => visitor.Visit(statement)).ToArray();
+            int finalElement = statements.Length - 1;
+            var body = statements
+                .Select((expression, index) =>
+                            index == finalElement && !IsVoid(returnType) ?
+                            ReturnStatement(expression as ExpressionSyntax) :
+                            ExpressionStatement(expression as ExpressionSyntax) as StatementSyntax)
+                .ToArray();
+            return MethodDeclaration(returnType, methodName)
+                    .WithParameterList(ParameterList(SeparatedList(parameterList)))
+                    .WithBody(Block(body));
+        }
+
+        private static bool IsVoid(TypeSyntax returnType)
+        {
+            var voidType = returnType as PredefinedTypeSyntax;
+            return voidType != null && voidType.Keyword.Kind() == SyntaxKind.VoidKeyword;
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/EqualityOperation.cs
+++ b/Donatello.Services/BuiltIns/EqualityOperation.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Donatello.StandardLibrary;
+
+namespace Donatello.Services.BuiltIns
+{
+    class EqualityOperation : IBuiltIn
+    {
+        private SyntaxKind equalityOperator;
+
+        public EqualityOperation(SyntaxKind equalityOperator)
+        {
+            this.equalityOperator = equalityOperator;
+        }
+
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var values = children
+                .Skip(1)
+                .Select(child => visitor.Visit(child) as ExpressionSyntax)
+                .ToArray();
+
+            // optimize for common scenario
+            if(values.Length == 2)
+            {
+                return ParenthesizedExpression(
+                    BinaryExpression(equalityOperator, values[0], values[1])
+                );
+            }
+
+            // create a var declaration for each operand.
+            var variableNames = Enumerable.Range(1, int.MaxValue)
+                                 .Select(n => "operand" + n)
+                                 .Take(values.Length)
+                                 .ToArray();
+            StatementSyntax[] variableDeclarations = variableNames
+                .Zip(values, (variable, value) =>
+                    LocalDeclarationStatement(
+                        VariableDeclaration(IdentifierName("var"))
+                            .WithVariables(SingletonSeparatedList(
+                                VariableDeclarator(Identifier(variable))
+                                .WithInitializer(EqualsValueClause(value))))))
+                .ToArray();
+
+            StatementSyntax andStatement = ReturnStatement(
+                // pairwise list visit to create [operand1 < operand2, operand2 < operand3, operand3 < operand4]
+                variableNames.Zip(variableNames.Skip(1),
+                    (a, b) => BinaryExpression(equalityOperator, IdentifierName(a), IdentifierName(b)))
+                // 'and' the comparisons together
+                .Aggregate((a, b) => BinaryExpression(SyntaxKind.LogicalAndExpression, a, b)));
+
+            // execute let expression
+            var lambda = ParenthesizedLambdaExpression(Block(variableDeclarations.Union(new[] { andStatement })));
+            return ParenthesizedExpression(
+                InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(nameof(Constructors)),
+                        IdentifierName(nameof(Constructors.CreateLet))))
+                    .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(lambda))))
+            );
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Fn.cs
+++ b/Donatello.Services/BuiltIns/Fn.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.BuiltIns;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Donatello.Services.Util;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class Fn : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            /*
+                (fn [a b] (+ a b))
+             */
+
+            var bindings = children[1].GetChild(0).Children().ToList();
+            var parameters = bindings.Skip(1).Take(bindings.Count - 2)
+                                    .Select(var => Parameter(Identifier(var.GetText())));
+            var expressions = children.Skip(2).Select(statement => visitor.Visit(statement)).ToArray();
+            int finalElement = expressions.Length - 1;
+            var statements = expressions
+                .Select((expression, index) =>
+                            index == finalElement ?
+                            ReturnStatement(expression as ExpressionSyntax) :
+                            ExpressionStatement(expression as ExpressionSyntax) as StatementSyntax)
+                .ToArray();
+            return ParenthesizedLambdaExpression(Block(statements))
+                    .WithParameterList(ParameterList(SeparatedList(parameters)));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/IBuiltIn.cs
+++ b/Donatello.Services/BuiltIns/IBuiltIn.cs
@@ -1,0 +1,14 @@
+﻿using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Donatello.Services.BuiltIns
+{
+    interface IBuiltIn
+    {
+        CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children);
+    }
+}

--- a/Donatello.Services/BuiltIns/If.cs
+++ b/Donatello.Services/BuiltIns/If.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.BuiltIns;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class If : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            // (if condition then-statement else-statement)
+            var condition = visitor.Visit(children[1]) as ExpressionSyntax;
+            var thenStatement = visitor.Visit(children[2]) as ExpressionSyntax;
+            var elseStatement = visitor.Visit(children[3]) as ExpressionSyntax;
+            return ParenthesizedExpression(
+                ConditionalExpression(condition, thenStatement, elseStatement)
+            );
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Instance.cs
+++ b/Donatello.Services/BuiltIns/Instance.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class Instance : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var baseTypesAndInterfaces = children
+                .Skip(1)
+                .Select(child => SimpleBaseType(ParseTypeName(child.GetText())))
+                .ToArray();
+            return BaseList(SeparatedList<BaseTypeSyntax>(baseTypesAndInterfaces));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Let.cs
+++ b/Donatello.Services/BuiltIns/Let.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Donatello.StandardLibrary;
+using System.Linq;
+using Donatello.Services.Util;
+using static Donatello.Services.Antlr.Generated.DonatelloParser;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class Let : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var bindings = children[1].GetChild(0);
+            var expressions = children.Skip(2).Select(statement => visitor.Visit(statement)).ToArray();
+            int finalElement = expressions.Length - 1;
+
+            var variables = bindings.As<VectorContext>().form().InPairs((name, value) =>
+            {
+                return LocalDeclarationStatement(
+                        VariableDeclaration(IdentifierName("var"))
+                        .WithVariables(SingletonSeparatedList(
+                            VariableDeclarator(Identifier(name.GetText()))
+                            .WithInitializer(EqualsValueClause(visitor.Visit(value) as ExpressionSyntax)))));
+            });
+
+            var statements = expressions
+                .Select((expression, index) =>
+                            index == finalElement ?
+                            ReturnStatement(expression as ExpressionSyntax) :
+                            ExpressionStatement(expression as ExpressionSyntax) as StatementSyntax);
+
+            var lambda = ParenthesizedLambdaExpression(Block(variables.Union(statements)));
+
+            return InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(nameof(Constructors)),
+                        IdentifierName(nameof(Constructors.CreateLet))))
+                    .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(lambda))));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/MathOperation.cs
+++ b/Donatello.Services/BuiltIns/MathOperation.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Donatello.Services.BuiltIns
+{
+    class MathOperation : IBuiltIn
+    {
+        private SyntaxKind binaryOperation;
+
+        public MathOperation(SyntaxKind binaryOperation)
+        {
+            this.binaryOperation = binaryOperation;
+        }
+
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var values = children.Skip(1).Select(child => visitor.Visit(child) as ExpressionSyntax);
+            return ParenthesizedExpression(
+                values.Aggregate((a, b) => BinaryExpression(binaryOperation, a, b))
+            );
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/New.cs
+++ b/Donatello.Services/BuiltIns/New.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class New : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var type = children[1].GetText();
+            var constructorParameters = children
+                .Skip(2)
+                .Select(child => Argument(visitor.Visit(child) as ExpressionSyntax));
+            return ObjectCreationExpression(ParseTypeName(type))
+                .WithArgumentList(ArgumentList(SeparatedList(constructorParameters)));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Pipe.cs
+++ b/Donatello.Services/BuiltIns/Pipe.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.BuiltIns;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Donatello.Services.Antlr.Generated.DonatelloParser;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class Pipe : IBuiltIn
+    {
+        private Func<IEnumerable<FormContext>, FormContext, IEnumerable<FormContext>> insertOperation;
+
+        /// <param name="insertOperation">operation that inserts a FormContext into an IEnumerable of FormContext</param>
+        public Pipe(Func<IEnumerable<FormContext>, FormContext, IEnumerable<FormContext>> insertOperation)
+        {
+            this.insertOperation = insertOperation;
+        }
+
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            /*
+              (pipe 5
+                  (* 3)
+                  (+ 10))
+             */
+            var piped = children
+                .Skip(2).Cast<FormContext>() // skip pipe character and input argument
+                .Aggregate(
+                    children.ElementAt(1) as FormContext, // initial seed is the input argument
+                    (previousOutput, partialFunction) =>
+                        // create a new list that is the partialFunction with the previousOutput prepended/appended.
+                        NewList(insertOperation(partialFunction.list().form(), previousOutput).ToArray())
+                );
+
+            var result = visitor.Visit(piped);
+            return result;
+        }
+
+        private static FormContext NewList(params FormContext[] forms)
+        {
+            var list = new ListContext(null, 0);
+            foreach (var element in forms)
+            {
+                list.AddChild(element);
+                element.Parent = list;
+            }
+            var form = new FormContext(null, 0);
+            form.AddChild(list);
+            return form;
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/Use.cs
+++ b/Donatello.Services/BuiltIns/Use.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using System.Linq;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class Use : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var target = children[1].GetText().Split('.');
+            if(target.Last() == "*")
+            {
+                return UsingDirective(
+                    Token(SyntaxKind.StaticKeyword),
+                    null,
+                    ParseName(string.Join(".", target.Take(target.Length - 1))));
+            }
+            return UsingDirective(ParseName(string.Join(".", target)));
+        }
+    }
+}

--- a/Donatello.Services/BuiltIns/UseMacro.cs
+++ b/Donatello.Services/BuiltIns/UseMacro.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Antlr4.Runtime.Tree;
+using Donatello.Services.Parser;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Donatello.Services.BuiltIns
+{
+    internal class UseMacro : IBuiltIn
+    {
+        public CSharpSyntaxNode Invoke(ParseExpressionVisitor visitor, IList<IParseTree> children)
+        {
+            var path = children[1].GetText();
+            Macros.ResolveMacro(path);
+            return EmptyStatement();
+        }
+    }
+}


### PR DESCRIPTION
BuiltInFunctions is a large class that does way too much. It also has private methods scattered through out the class that aren't reused across the different built in functions.

This PR breaks this mega class apart into smaller classes that implement IBuiltIn